### PR TITLE
Added hostname to the consumer tag

### DIFF
--- a/amqp/consumer.go
+++ b/amqp/consumer.go
@@ -74,6 +74,12 @@ func NewConsumer(c messaging.Connection, autoAck bool, exchange, queue string) (
 
 // NewConsumerConfig returns a new AMQP Consumer.
 func NewConsumerConfig(c messaging.Connection, autoAck bool, exchange, queue string, config ConsumerConfig) (*consumer, error) {
+
+	hostname, err := os.Hostname()
+	if err != nil {
+		hostname = "unknown"
+	}
+
 	consumer := &consumer{
 		config:          config,
 		conn:            c.(*Connection),
@@ -81,10 +87,10 @@ func NewConsumerConfig(c messaging.Connection, autoAck bool, exchange, queue str
 		handlers:        make([]handler, 0),
 		exchangeName:    exchange,
 		queueName:       queue,
-		consumerTagName: fmt.Sprintf("ctag-%s-%s-%d", os.Hostname(), os.Args[0], atomic.AddUint64(&consumerTagSeq, 1)),
+		consumerTagName: fmt.Sprintf("ctag-%s-%s-%d", hostname, os.Args[0], atomic.AddUint64(&consumerTagSeq, 1)),
 	}
 
-	err := consumer.setupTopology()
+	err = consumer.setupTopology()
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Added the hostname to the consumerTag at rabbitMQ. Still using the os.args[0] and an unique incremental value as it is used in the default implementation https://github.com/streadway/amqp/blob/08577bbc9535a8f693ff7f57631b1deac748fe8f/consumers.go#L17