### PR TITLE
Always setup topology when start consume.

### DIFF
--- a/amqp/connection.go
+++ b/amqp/connection.go
@@ -113,6 +113,11 @@ func (c *connection) WaitUntilConnectionCloses() {
 	<-c.NotifyConnectionClose()
 }
 
+// WaitUntilConnectionReestablished holds the execution until the connection reestablished.
+func (c *connection) WaitUntilConnectionReestablished() {
+	<-c.NotifyReestablish()
+}
+
 func (c *connection) dial() error {
 	conn, err := amqplib.Dial(c.url)
 

--- a/amqp/producer.go
+++ b/amqp/producer.go
@@ -140,10 +140,6 @@ func (p *producer) setupTopology() error {
 		if err != nil {
 			return err
 		}
-
-		if err != nil {
-			return err
-		}
 	}
 
 	log.WithFields(log.Fields{
@@ -155,10 +151,8 @@ func (p *producer) setupTopology() error {
 }
 
 func (p *producer) handleReestablishedConnnection() {
-	reestablishChannel := p.conn.NotifyReestablish()
-
 	for !p.closed {
-		<-reestablishChannel
+		p.conn.WaitUntilConnectionReestablished()
 
 		err := p.setupTopology()
 
@@ -217,6 +211,7 @@ func (p *producer) drainInternalQueue() {
 				"message_id": m.msg.MessageId,
 				"type":       "goevents",
 				"sub_type":   "producer",
+				"exchange":   p.exchangeName,
 			}).Info("Publishing message to the exchange.")
 
 			err := p.publishMessage(m.msg, m.action)

--- a/amqp/producer_test.go
+++ b/amqp/producer_test.go
@@ -36,6 +36,9 @@ func TestPublish(t *testing.T) {
 
 				go c.Consume()
 
+				// take a time to setup topology
+				time.Sleep(SleepSetupTopology)
+
 				p, err := NewProducer(conn, "webhooks")
 
 				if assert.Nil(t, err) {
@@ -78,6 +81,9 @@ func TestPublishMultipleTimes(t *testing.T) {
 				}, nil)
 
 				go c.Consume()
+
+				// take a time to setup topology
+				time.Sleep(SleepSetupTopology)
 
 				p, err := NewProducer(conn, "webhooks")
 

--- a/examples/consumer/consumer.go
+++ b/examples/consumer/consumer.go
@@ -21,8 +21,6 @@ func main() {
 	consumerA, err := amqp.NewConsumerConfig(conn, false, "events-exchange", "events-queue-a", amqp.ConsumerConfig{
 		ConsumeRetryInterval: 2 * time.Second,
 		PrefetchCount:        1,
-		DurableQueue:         true,
-		AutoDelete:           false,
 	})
 
 	if err != nil {

--- a/messaging/connection.go
+++ b/messaging/connection.go
@@ -7,5 +7,6 @@ type Connection interface {
 	NotifyConnectionClose() <-chan error
 	NotifyReestablish() <-chan bool
 	WaitUntilConnectionCloses()
+	WaitUntilConnectionReestablished()
 	IsConnected() bool
 }

--- a/mock/connection.go
+++ b/mock/connection.go
@@ -41,6 +41,10 @@ func (c *Connection) WaitUntilConnectionCloses() {
 	c.Called()
 }
 
+func (c *Connection) WaitUntilConnectionReestablished() {
+	c.Called()
+}
+
 func (c *Connection) IsConnected() bool {
 	args := c.Called()
 	return args.Get(0).(bool)


### PR DESCRIPTION
Antes era feito um setupTopology sempre que a conexão restabelicia. O que gera um overhead inutil, já que são abertos 2 channels, um para definir a topologia e outro pra fazer o consume.
Dessa forma, além de diminuir overhead, também reduzimos problemas em casos de exchange ou queue não declarada.