### PR TITLE
Added travis_retry to better handle test running in travis environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ services:
 addons:
   hosts:
     - broker
-script: go test -v ./...
+script: travis_retry go test -v ./...
 notifications:
   email:
     recipients:


### PR DESCRIPTION
Sometimes like #38 the test fail because of some race condition, the `travis_retry` command try run any passed param 3 times, if it fails is garanted that is a real error, if not, is only a circumstantial error that probably need less atention.