### PR TITLE
Feat/dual consumer

### DIFF
--- a/sns/consumer.go
+++ b/sns/consumer.go
@@ -454,6 +454,7 @@ func checkPriorityMessages(consumers []*consumer, currentConsumer *consumer) boo
 
 		// If any higher priority consumer has messages to consume, then the currentConsumer should not consume.
 		if len(consumer.qos) > 0 {
+			logrus.Debugf("Higher priority consumer %s has messages to consume, skipping current consumer %s", consumer.config.QueueUrl, currentConsumer.config.QueueUrl)
 			return false
 		}
 	}


### PR DESCRIPTION
This pull request introduces significant improvements to our message consumption system, primarily focusing on the creation of a new `PriorityConsume` function and enhanced debugging. Here's a breakdown of the changes:

1. **Creation of `PriorityConsume` function:** A new function has been introduced that accepts a slice of `messaging.Consumer` interfaces and begins consuming them in order of their priority. The function is equipped to cast the `messaging.Consumer` interface to a specific `*consumer` type for further processing. It also includes a mechanism to track and stop consumers as necessary.

2. **Improved Logging:** A debug log statement has been added to output when a higher priority consumer has messages in the queue, thereby skipping the current consumer. This addition will significantly aid in troubleshooting and understanding the flow of message consumption based on priority.

3. **Estimating the Number of Messages in SQS Queue:** The `approximateNumberOfMessages` function has been added, which leverages AWS SQS's GetQueueAttributes SDK to fetch an estimated count of the messages currently in the queue. This functionality can be used to understand the load on a queue and adjust processing accordingly.

4. **Enhanced Documentation:** All code changes have been accompanied by comprehensive comments explaining the functionality of each step and providing context where necessary. This enhanced documentation will facilitate easier understanding and maintenance of the code.

Please review these changes and provide your feedback @tatuzex1 